### PR TITLE
toHex 0 padding - fewer bytes

### DIFF
--- a/hex-rgb.js
+++ b/hex-rgb.js
@@ -1,1 +1,1 @@
-(function(b){b.toRGB=function(a){a=parseInt(a,16);return[a>>16,a>>8&255,a&255]};b.toHex=function(a,b,c){a=(c|b<<8|a<<16).toString(16);return"000000".substr(0,6-a.length)+a}})(this);
+(function(a){a["toRGB"]=function(a){var b=parseInt(a,16);return[b>>16,b>>8&255,b&255]};a["toHex"]=function(a,b,c){return(c|b<<8|a<<16|1<<24).toString(16).slice(1)}})(this);

--- a/hex-rgb.src.js
+++ b/hex-rgb.src.js
@@ -52,10 +52,7 @@
         //
         // example:
         //	var hex = toHex(255, 0, 0);
-        var hex = (blue | green << 8 | red << 16).toString(16);
-
-        //fix for leading zero bug in FF
-        return "000000".substr(0, 6 - hex.length) + hex;
+        return ((blue | green << 8 | red << 16) | 1 << 24).toString(16).slice(1);
     };
 
 })(this);


### PR DESCRIPTION
A different method for padding a (0,0,255) value to 0000FF instead of FF, which is shorter than the one currently used.
